### PR TITLE
feat: add company charges endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Company charges endpoints: `list_charges()` for a company's registered charges (mortgages) with pagination, and `get_charge()` for a single charge by ID
+- `Charge` and `ChargeList` models (plus `ChargeStatus`, `ChargeClassification`, `ChargeParticulars`, `SecuredDetails`, `PersonEntitled`, `ChargeLinks`, `ChargeTransaction`, `TransactionLinks`, `InsolvencyCase`) covering the Companies House charges resource
+
 ## [0.6.0] - 2025-08-08
 
 ### Added

--- a/src/ukcompanies/__init__.py
+++ b/src/ukcompanies/__init__.py
@@ -15,6 +15,8 @@ from .exceptions import (
 from .models import (
     Address,
     BaseModel,
+    Charge,
+    ChargeList,
     Company,
     CompanySearchResult,
     OfficerSearchResult,
@@ -32,6 +34,8 @@ __all__ = [
     # Models
     "BaseModel",
     "Address",
+    "Charge",
+    "ChargeList",
     "Company",
     "CompanySearchResult",
     "OfficerSearchResult",

--- a/src/ukcompanies/client_endpoints.py
+++ b/src/ukcompanies/client_endpoints.py
@@ -10,6 +10,7 @@ import structlog
 from .exceptions import RateLimitError, ServerError, ValidationError
 from .models import Address, Company
 from .models.appointment import AppointmentList
+from .models.charge import Charge, ChargeList
 from .models.disqualification import DisqualificationList
 from .models.document import Document, DocumentContent, DocumentFormat, DocumentMetadata
 from .models.filing import FilingCategory, FilingHistoryList, FilingTransaction
@@ -444,6 +445,67 @@ class EndpointMixin:
 
         response = await self.get(f"/company/{normalized}/filing-history/{clean_id}")
         return FilingTransaction(**response)
+
+    async def list_charges(
+        self,
+        company_number: str,
+        items_per_page: int = 25,
+        start_index: int = 0,
+    ) -> ChargeList:
+        """List the charges (mortgages) registered against a company.
+
+        Args:
+            company_number: Company registration number
+            items_per_page: Number of items per page (max 100)
+            start_index: Starting index for pagination
+
+        Returns:
+            ChargeList with the company's charges
+
+        Raises:
+            ValidationError: If company number is invalid
+            NotFoundError: If company doesn't exist
+        """
+        # Validate and normalize company number
+        normalized = self.validate_company_number(company_number)
+
+        params = {
+            "items_per_page": min(items_per_page, 100),
+            "start_index": start_index,
+        }
+
+        response = await self.get(f"/company/{normalized}/charges", params=params)
+        return ChargeList(**response)
+
+    async def get_charge(
+        self,
+        company_number: str,
+        charge_id: str,
+    ) -> Charge:
+        """Get details of a single charge registered against a company.
+
+        Args:
+            company_number: Company registration number
+            charge_id: Unique charge identifier
+
+        Returns:
+            Charge with detailed charge information
+
+        Raises:
+            ValidationError: If company number or charge ID is invalid
+            NotFoundError: If company or charge doesn't exist
+        """
+        # Validate and normalize company number
+        normalized = self.validate_company_number(company_number)
+
+        # Validate charge ID
+        if not charge_id or not charge_id.strip():
+            raise ValidationError("Charge ID cannot be empty")
+
+        clean_id = charge_id.strip()
+
+        response = await self.get(f"/company/{normalized}/charges/{clean_id}")
+        return Charge(**response)
 
     async def document(self, document_id: str) -> Document:
         """Get document metadata.

--- a/src/ukcompanies/models/__init__.py
+++ b/src/ukcompanies/models/__init__.py
@@ -4,6 +4,19 @@ from .address import Address
 from .appointment import Appointment, AppointmentList
 from .appointment import CompanyStatus as AppointmentCompanyStatus
 from .base import BaseModel
+from .charge import (
+    Charge,
+    ChargeClassification,
+    ChargeLinks,
+    ChargeList,
+    ChargeParticulars,
+    ChargeStatus,
+    ChargeTransaction,
+    InsolvencyCase,
+    PersonEntitled,
+    SecuredDetails,
+    TransactionLinks,
+)
 from .company import (
     AccountingReference,
     Accounts,
@@ -50,6 +63,18 @@ __all__ = [
     "AccountingReference",
     "ConfirmationStatement",
     "Accounts",
+    # Charge
+    "Charge",
+    "ChargeList",
+    "ChargeStatus",
+    "ChargeClassification",
+    "ChargeParticulars",
+    "SecuredDetails",
+    "PersonEntitled",
+    "ChargeLinks",
+    "ChargeTransaction",
+    "TransactionLinks",
+    "InsolvencyCase",
     # Officer
     "Officer",
     "OfficerList",

--- a/src/ukcompanies/models/charge.py
+++ b/src/ukcompanies/models/charge.py
@@ -1,0 +1,158 @@
+"""Charge (company mortgages/charges) models for UK Companies API."""
+
+from datetime import date
+from enum import Enum
+from typing import Any
+
+from pydantic import Field
+
+from .base import BaseModel
+
+
+class ChargeStatus(str, Enum):
+    """Status of a registered charge."""
+
+    OUTSTANDING = "outstanding"
+    FULLY_SATISFIED = "fully-satisfied"
+    PART_SATISFIED = "part-satisfied"
+    SATISFIED = "satisfied"
+
+
+class ChargeClassification(BaseModel):
+    """Classification (type) of a charge."""
+
+    classification_type: str | None = Field(
+        None,
+        alias="type",
+        description="Classification type, e.g. 'charge-description'",
+    )
+    description: str | None = Field(None, description="Classification description")
+
+
+class ChargeParticulars(BaseModel):
+    """Particulars describing what the charge covers."""
+
+    type: str | None = Field(None, description="Type of particulars")
+    description: str | None = Field(None, description="Free-text description")
+    contains_fixed_charge: bool | None = Field(
+        None, description="Whether a fixed charge is included"
+    )
+    contains_floating_charge: bool | None = Field(
+        None, description="Whether a floating charge is included"
+    )
+    contains_negative_pledge: bool | None = Field(
+        None, description="Whether a negative pledge is included"
+    )
+    floating_charge_covers_all: bool | None = Field(
+        None, description="Whether the floating charge covers all property/undertaking"
+    )
+    chargor_acting_as_bare_trustee: bool | None = Field(
+        None, description="Whether the chargor acts as a bare trustee"
+    )
+
+
+class SecuredDetails(BaseModel):
+    """Details of the amount/obligation secured by the charge."""
+
+    type: str | None = Field(None, description="Type of secured details")
+    description: str | None = Field(None, description="Description of what is secured")
+
+
+class PersonEntitled(BaseModel):
+    """A person entitled to the charge."""
+
+    name: str | None = Field(None, description="Name of the person entitled")
+
+
+class ChargeLinks(BaseModel):
+    """Links associated with a charge."""
+
+    self: str | None = Field(None, description="Link to this charge resource")
+    transactions: str | None = Field(None, description="Link to charge transactions")
+    insolvency_cases: str | None = Field(None, description="Link to insolvency cases")
+
+
+class TransactionLinks(BaseModel):
+    """Links for a charge transaction."""
+
+    filing: str | None = Field(None, description="Link to the associated filing")
+    insolvency_case: str | None = Field(None, description="Link to insolvency case")
+
+
+class ChargeTransaction(BaseModel):
+    """A transaction (filing event) against a charge."""
+
+    transaction_id: str | None = Field(None, description="Transaction identifier")
+    filing_type: str | None = Field(None, description="Filing type of the transaction")
+    delivered_on: date | None = Field(None, description="Date the transaction was delivered")
+    insolvency_case_number: int | None = Field(
+        None, description="Associated insolvency case number"
+    )
+    links: TransactionLinks | None = Field(None, description="Related links")
+
+
+class InsolvencyCase(BaseModel):
+    """An insolvency case linked to a charge."""
+
+    case_number: int | None = Field(None, description="Insolvency case number")
+    case_type: str | None = Field(None, description="Type of insolvency case")
+    description: str | None = Field(None, description="Case description")
+    links: dict[str, Any] | None = Field(None, description="Related links")
+
+
+class Charge(BaseModel):
+    """A single registered charge (mortgage) against a company."""
+
+    id: str | None = Field(None, alias="charge_id", description="Charge identifier")
+    charge_code: str | None = Field(None, description="Charge code")
+    charge_number: int | None = Field(None, description="Sequential charge number")
+    classification: ChargeClassification | None = Field(
+        None, description="Charge classification"
+    )
+    status: ChargeStatus | None = Field(None, description="Status of the charge")
+    assets_ceased_released: str | None = Field(
+        None, description="Reason assets ceased to be / were released"
+    )
+    acquired_on: date | None = Field(None, description="Date the charge was acquired")
+    created_on: date | None = Field(None, description="Date the charge was created")
+    delivered_on: date | None = Field(None, description="Date the charge was delivered")
+    resolved_on: date | None = Field(None, description="Date the charge was resolved")
+    covering_instrument_date: date | None = Field(
+        None, description="Date of the covering instrument"
+    )
+    satisfied_on: date | None = Field(None, description="Date the charge was satisfied")
+    particulars: ChargeParticulars | None = Field(
+        None, description="Particulars of the charge"
+    )
+    secured_details: SecuredDetails | None = Field(
+        None, description="Details of the secured obligation"
+    )
+    scottish_alterations: dict[str, Any] | None = Field(
+        None, description="Scottish alteration details"
+    )
+    more_than_four_persons_entitled: bool | None = Field(
+        None, description="Whether more than four persons are entitled"
+    )
+    persons_entitled: list[PersonEntitled] | None = Field(
+        None, description="Persons entitled to the charge"
+    )
+    transactions: list[ChargeTransaction] | None = Field(
+        None, description="Transactions against the charge"
+    )
+    insolvency_cases: list[InsolvencyCase] | None = Field(
+        None, description="Insolvency cases linked to the charge"
+    )
+    links: ChargeLinks | None = Field(None, description="Related links")
+
+
+class ChargeList(BaseModel):
+    """Paginated list of charges for a company."""
+
+    etag: str | None = Field(None, description="ETag for the resource")
+    total_count: int = Field(0, description="Total number of charges")
+    unfiled_count: int | None = Field(None, description="Number of unfiled charges")
+    satisfied_count: int | None = Field(None, description="Number of satisfied charges")
+    part_satisfied_count: int | None = Field(
+        None, description="Number of part-satisfied charges"
+    )
+    items: list[Charge] = Field(default_factory=list, description="List of charges")

--- a/tests/unit/test_charges.py
+++ b/tests/unit/test_charges.py
@@ -1,0 +1,255 @@
+"""Unit tests for charge models and charge endpoints."""
+
+from datetime import date
+
+import pytest
+import respx
+from httpx import Response
+
+from ukcompanies import AsyncClient
+from ukcompanies.exceptions import NotFoundError, ValidationError
+from ukcompanies.models.charge import (
+    Charge,
+    ChargeClassification,
+    ChargeList,
+    ChargeStatus,
+    ChargeTransaction,
+    PersonEntitled,
+)
+
+BASE_URL = "https://api.company-information.service.gov.uk"
+
+
+# Realistic charges list fixture, shaped like the Companies House charges resource.
+CHARGES_LIST_FIXTURE = {
+    "etag": "abc123def456",
+    "total_count": 2,
+    "unfiled_count": 0,
+    "satisfied_count": 1,
+    "part_satisfied_count": 0,
+    "items": [
+        {
+            "charge_id": "AbC1dEfGhIjKlMnOpQrStUvWxYz",
+            "charge_code": "001234560001",
+            "charge_number": 1,
+            "classification": {
+                "type": "charge-description",
+                "description": "A registered charge",
+            },
+            "status": "outstanding",
+            "created_on": "2023-05-01",
+            "delivered_on": "2023-05-08",
+            "particulars": {
+                "type": "brief-description",
+                "description": "The freehold property known as 1 Example Street.",
+                "contains_fixed_charge": True,
+                "contains_floating_charge": False,
+                "contains_negative_pledge": True,
+            },
+            "secured_details": {
+                "type": "amount-secured",
+                "description": "All monies due or to become due.",
+            },
+            "persons_entitled": [
+                {"name": "Big Bank PLC"},
+            ],
+            "transactions": [
+                {
+                    "transaction_id": "MzM2NTY5MzQ1OGFkaXF6a2N4",
+                    "filing_type": "create-charge",
+                    "delivered_on": "2023-05-08",
+                    "links": {
+                        "filing": "/company/12345678/filing-history/MzM2NTY5MzQ1OGFkaXF6a2N4"
+                    },
+                }
+            ],
+            "links": {
+                "self": "/company/12345678/charges/AbC1dEfGhIjKlMnOpQrStUvWxYz"
+            },
+        },
+        {
+            "charge_id": "ZyXwVuTsRqPoNmLkJiHgFeDcBa",
+            "charge_code": "001234560002",
+            "charge_number": 2,
+            "classification": {
+                "type": "charge-description",
+                "description": "A registered charge",
+            },
+            "status": "fully-satisfied",
+            "created_on": "2020-01-10",
+            "delivered_on": "2020-01-15",
+            "satisfied_on": "2022-11-30",
+            "persons_entitled": [
+                {"name": "Small Lender Ltd"},
+            ],
+            "links": {
+                "self": "/company/12345678/charges/ZyXwVuTsRqPoNmLkJiHgFeDcBa"
+            },
+        },
+    ],
+}
+
+
+class TestChargeStatus:
+    """Test ChargeStatus enum."""
+
+    def test_charge_status_values(self):
+        """Test that charge statuses have correct values."""
+        assert ChargeStatus.OUTSTANDING.value == "outstanding"
+        assert ChargeStatus.FULLY_SATISFIED.value == "fully-satisfied"
+        assert ChargeStatus.PART_SATISFIED.value == "part-satisfied"
+        assert ChargeStatus.SATISFIED.value == "satisfied"
+
+    def test_charge_status_from_string(self):
+        """Test creating status from string."""
+        assert ChargeStatus("outstanding") == ChargeStatus.OUTSTANDING
+
+
+class TestChargeModel:
+    """Test parsing the Charge / ChargeList models from realistic JSON."""
+
+    def test_charge_list_parses_fixture(self):
+        """Test that a realistic charges payload parses fully."""
+        charge_list = ChargeList(**CHARGES_LIST_FIXTURE)
+
+        assert charge_list.total_count == 2
+        assert charge_list.satisfied_count == 1
+        assert charge_list.unfiled_count == 0
+        assert charge_list.etag == "abc123def456"
+        assert len(charge_list.items) == 2
+
+        first = charge_list.items[0]
+        assert isinstance(first, Charge)
+        # charge_id is aliased to id
+        assert first.id == "AbC1dEfGhIjKlMnOpQrStUvWxYz"
+        assert first.charge_code == "001234560001"
+        assert first.charge_number == 1
+        assert first.status == "outstanding"
+        assert first.created_on == date(2023, 5, 1)
+        assert first.delivered_on == date(2023, 5, 8)
+        assert first.satisfied_on is None
+
+        assert isinstance(first.classification, ChargeClassification)
+        assert first.classification.classification_type == "charge-description"
+        assert first.classification.description == "A registered charge"
+
+        assert first.particulars.contains_fixed_charge is True
+        assert first.particulars.contains_floating_charge is False
+        assert first.secured_details.description == "All monies due or to become due."
+
+        assert first.persons_entitled == [PersonEntitled(name="Big Bank PLC")]
+
+        assert len(first.transactions) == 1
+        txn = first.transactions[0]
+        assert isinstance(txn, ChargeTransaction)
+        assert txn.transaction_id == "MzM2NTY5MzQ1OGFkaXF6a2N4"
+        assert txn.filing_type == "create-charge"
+        assert txn.delivered_on == date(2023, 5, 8)
+
+        assert first.links.self == "/company/12345678/charges/AbC1dEfGhIjKlMnOpQrStUvWxYz"
+
+        second = charge_list.items[1]
+        assert second.status == "fully-satisfied"
+        assert second.satisfied_on == date(2022, 11, 30)
+        # Missing optional keys stay None / empty.
+        assert second.particulars is None
+        assert second.transactions is None
+
+    def test_charge_list_empty(self):
+        """Test that an empty list is tolerated with sensible defaults."""
+        charge_list = ChargeList()
+        assert charge_list.items == []
+        assert charge_list.total_count == 0
+        assert charge_list.satisfied_count is None
+
+    def test_charge_tolerates_missing_keys(self):
+        """Test that a sparse charge (only id) parses without error."""
+        charge = Charge(charge_id="XYZ")
+        assert charge.id == "XYZ"
+        assert charge.status is None
+        assert charge.created_on is None
+        assert charge.persons_entitled is None
+
+
+@pytest.mark.asyncio
+class TestListCharges:
+    """Test the list_charges endpoint."""
+
+    async def test_list_charges_success(self):
+        """Test successful charges listing (mocked)."""
+        async with AsyncClient(api_key="test_key") as client:
+            with respx.mock:
+                route = respx.get(f"{BASE_URL}/company/12345678/charges").mock(
+                    return_value=Response(200, json=CHARGES_LIST_FIXTURE)
+                )
+
+                result = await client.list_charges("12345678")
+
+                assert route.called
+                assert route.call_count == 1
+                assert isinstance(result, ChargeList)
+                assert result.total_count == 2
+                assert len(result.items) == 2
+                assert result.items[0].id == "AbC1dEfGhIjKlMnOpQrStUvWxYz"
+                assert result.items[0].status == "outstanding"
+                assert result.items[1].status == "fully-satisfied"
+
+    async def test_list_charges_not_found(self):
+        """Test list_charges raises NotFoundError for an unknown company."""
+        async with AsyncClient(api_key="test_key") as client:
+            with respx.mock:
+                route = respx.get(f"{BASE_URL}/company/99999999/charges").mock(
+                    return_value=Response(
+                        404, json={"error": "company-profile-not-found"}
+                    )
+                )
+
+                with pytest.raises(NotFoundError) as exc_info:
+                    await client.list_charges("99999999")
+
+                assert route.called
+                assert "not found" in str(exc_info.value).lower()
+
+
+@pytest.mark.asyncio
+class TestGetCharge:
+    """Test the get_charge endpoint."""
+
+    async def test_get_charge_success(self):
+        """Test successful single-charge retrieval (mocked)."""
+        charge_fixture = CHARGES_LIST_FIXTURE["items"][0]
+        charge_id = charge_fixture["charge_id"]
+
+        async with AsyncClient(api_key="test_key") as client:
+            with respx.mock:
+                route = respx.get(
+                    f"{BASE_URL}/company/12345678/charges/{charge_id}"
+                ).mock(return_value=Response(200, json=charge_fixture))
+
+                result = await client.get_charge("12345678", charge_id)
+
+                assert route.called
+                assert isinstance(result, Charge)
+                assert result.id == charge_id
+                assert result.charge_code == "001234560001"
+                assert result.status == "outstanding"
+                assert result.classification.description == "A registered charge"
+
+    async def test_get_charge_not_found(self):
+        """Test get_charge raises NotFoundError for an unknown charge."""
+        async with AsyncClient(api_key="test_key") as client:
+            with respx.mock:
+                route = respx.get(
+                    f"{BASE_URL}/company/12345678/charges/does-not-exist"
+                ).mock(return_value=Response(404, json={"error": "charge-not-found"}))
+
+                with pytest.raises(NotFoundError):
+                    await client.get_charge("12345678", "does-not-exist")
+
+                assert route.called
+
+    async def test_get_charge_empty_id_raises(self):
+        """Test that an empty charge ID raises ValidationError before any request."""
+        async with AsyncClient(api_key="test_key") as client:
+            with pytest.raises(ValidationError):
+                await client.get_charge("12345678", "   ")


### PR DESCRIPTION
## Summary
Adds **Company Charges** support to the SDK, covering two Companies House endpoints that were previously missing:

- `list_charges(company_number, items_per_page=25, start_index=0)` → `GET /company/{number}/charges`
- `get_charge(company_number, charge_id)` → `GET /company/{number}/charges/{id}`

## Changes
- New `Charge` / `ChargeList` Pydantic models (`src/ukcompanies/models/charge.py`) covering particulars, secured details, transactions, insolvency cases, persons entitled, and links — tolerant of missing keys like existing models.
- Exported from `models/__init__.py` and top-level `__init__.py`.
- Two async client methods following the existing `filing_history` style (company-number validation, params dict, `Model(**response)`).
- 10 unit tests in `tests/unit/test_charges.py` (model parsing, list happy path, single-charge happy path, 404 handling).
- CHANGELOG [Unreleased] updated.

## Testing
- `tests/unit/test_charges.py`: **10 passed**
- Full unit suite: **259 passed, 1 failed** — the single failure (`test_extra_fields_forbidden`) is **pre-existing on the base commit** and unrelated to this change.

_Implemented via the Kiln multi-model pipeline in an isolated container as an evaluation exercise._