### PR TITLE
release: 0.7.0

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -89,7 +89,8 @@ jobs:
       run: |
         python -m venv test_env
         source test_env/bin/activate
-        pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ ukcompanies==${{ github.ref_name }}
+        VERSION="${GITHUB_REF_NAME#v}"
+        pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ "ukcompanies==${VERSION}"
         python -c "import ukcompanies; print(f'Version: {ukcompanies.__version__}')"
         python -m ukcompanies --help
 
@@ -119,6 +120,7 @@ jobs:
       run: |
         python -m venv test_env
         source test_env/bin/activate
-        pip install ukcompanies==${{ github.ref_name }}
+        VERSION="${GITHUB_REF_NAME#v}"
+        pip install "ukcompanies==${VERSION}"
         python -c "import ukcompanies; print(f'Version: {ukcompanies.__version__}')"
         python -m ukcompanies --help

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0] - 2026-07-08
+
 ### Added
 - Company charges endpoints: `list_charges()` for a company's registered charges (mortgages) with pagination, and `get_charge()` for a single charge by ID
 - `Charge` and `ChargeList` models (plus `ChargeStatus`, `ChargeClassification`, `ChargeParticulars`, `SecuredDetails`, `PersonEntitled`, `ChargeLinks`, `ChargeTransaction`, `TransactionLinks`, `InsolvencyCase`) covering the Companies House charges resource

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ukcompanies"
-version = "0.6.0"
+version = "0.7.0"
 description = "A Python SDK for accessing UK Companies House API"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/ukcompanies/__init__.py
+++ b/src/ukcompanies/__init__.py
@@ -23,7 +23,7 @@ from .models import (
     RateLimitInfo,
 )
 
-__version__ = "0.1.0"
+__version__ = "0.7.0"
 
 __all__ = [
     "__version__",


### PR DESCRIPTION
Release prep for **0.7.0** (company charges endpoints).

## Changes
- `pyproject.toml`: `0.6.0` → `0.7.0`.
- `src/ukcompanies/__init__.py`: `__version__` `0.1.0` → `0.7.0` (was stale/out of sync with pyproject).
- `CHANGELOG.md`: move the charges entries under a dated `[0.7.0] - 2026-07-08`; fresh empty `[Unreleased]`.
- `.github/workflows/publish.yml`: **fix a release-blocking bug** — the post-publish install checks did `pip install ukcompanies==${{ github.ref_name }}` = `==v0.7.0` (with the `v`), but the version is `0.7.0`. The TestPyPI job would fail on this and, because `publish-pypi` `needs: publish-testpypi`, the real publish would be **skipped**. Now strips the `v` via `${GITHUB_REF_NAME#v}`.

## After merge — to actually publish
1. Set two repo secrets (values never in chat): `TEST_PYPI_API_TOKEN`, `PYPI_API_TOKEN`.
2. Tag `v0.7.0` and push → workflow runs test → build → TestPyPI → PyPI.

Verified locally: `uv build` → 0.7.0 artifacts, `__version__` == 0.7.0, ruff/mypy/pytest green.